### PR TITLE
enable Vagrantfile to up/destroy multiple machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Then you can then use the `docker` command from your local shell by setting `DOC
 
 ```bash
 # Start master machine
-ROLE=master IP=172.17.8.100 vagrant up
+vagrant up kube-master
 
-ROLE=master vagrant ssh -c 'cat /etc/systemd/system/etcd2.service.d/initial-cluster.conf'
+vagrant ssh kube-master -c 'cat /etc/systemd/system/etcd2.service.d/initial-cluster.conf'
 # open `setup/cloud-init/node-data` file to replace the value in `coreos/etcd2/initial-cluster`. ex:
 initial-cluster: "e0100b6a52d049aeacf52b529d13d006=http://172.17.8.100:2380"
 ```
@@ -137,8 +137,8 @@ Find more [details](./docs/start-master-and-node-machine.md)
 **Node machine**
 
 ```bash
-IP=172.17.8.101 NUM=1 vagrant up
-IP=172.17.8.102 NUM=2 vagrant up
+export NUM_NODES=2
+vagrant up
 ```
 
 Find more [details](./docs/start-master-and-node-machine.md)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,21 +4,8 @@
 require 'fileutils'
 Vagrant.require_version ">= 1.6.0"
 
-# The current ROLE of this CoreOS distro
-# @params "master" or "node". load different cloud-init config
-$role = ENV['ROLE'] || 'node'
-
-# Public ip address of the current machine
-$ip = ENV['IP'] || "172.17.8.101"
-
-# Change basename of the VM. Default: "core"
-if $role == "master"
-  $machine_name = "kube-%s" % $role
-else
-  # show the count of the current kube-node-#{count}. ex: kube-node-01
-  $node_number = ENV['NUM'] || 1
-  $machine_name = "kube-%s-%02d" % [$role, $node_number]
-end
+$num_nodes=ENV['NUM_NODES'] || 1
+$base_ip_addr=ENV['BASE_IP_ADDR'] || "172.17.8"
 
 # Change the version of CoreOS to be installed. Default: "current"
 # For example, to deploy version 709.0.0, set $image_version="709.0.0"
@@ -105,79 +92,90 @@ Vagrant.configure($Vagrantfile_api_version) do |config|
     config.vbguest.auto_update = false
   end
 
-  config.vm.define vm_name = "%s" % $machine_name do |config|
-    config.vm.hostname = vm_name
+  (0..$num_nodes).each do |i|
+    if i == 0
+      hostname = "kube-master"
+      role = "master"
+    else
+      hostname = "kube-node-%02d" % i
+      role = "node"
+    end
+	ip = "%s.%d" % [$base_ip_addr, i+100]
 
-    if $enable_serial_logging
-      logdir = File.join(File.dirname(__FILE__), "log")
-      FileUtils.mkdir_p(logdir)
+    config.vm.define vm_name = hostname do |config|
+      config.vm.hostname = vm_name
 
-      serialFile = File.join(logdir, "%s-serial.txt" % vm_name)
-      FileUtils.touch(serialFile)
+      if $enable_serial_logging
+        logdir = File.join(File.dirname(__FILE__), "log")
+        FileUtils.mkdir_p(logdir)
 
-      ["vmware_fusion", "vmware_workstation"].each do |vmware|
-        config.vm.provider vmware do |v, override|
-          v.vmx["serial0.present"] = "TRUE"
-          v.vmx["serial0.fileType"] = "file"
-          v.vmx["serial0.fileName"] = serialFile
-          v.vmx["serial0.tryNoRxLoss"] = "FALSE"
+        serialFile = File.join(logdir, "%s-serial.txt" % vm_name)
+        FileUtils.touch(serialFile)
+
+        ["vmware_fusion", "vmware_workstation"].each do |vmware|
+          config.vm.provider vmware do |v, override|
+            v.vmx["serial0.present"] = "TRUE"
+            v.vmx["serial0.fileType"] = "file"
+            v.vmx["serial0.fileName"] = serialFile
+            v.vmx["serial0.tryNoRxLoss"] = "FALSE"
+          end
+        end
+
+        config.vm.provider :virtualbox do |vb, override|
+          vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+          vb.customize ["modifyvm", :id, "--uartmode1", serialFile]
         end
       end
 
-      config.vm.provider :virtualbox do |vb, override|
-        vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
-        vb.customize ["modifyvm", :id, "--uartmode1", serialFile]
+      if $expose_docker_tcp
+        config.vm.network "forwarded_port", guest: 2375, host: $expose_docker_tcp, auto_correct: true
       end
-    end
 
-    if $expose_docker_tcp
-      config.vm.network "forwarded_port", guest: 2375, host: $expose_docker_tcp, auto_correct: true
-    end
-
-    # Create a forwarded port mapping which allows access to a specific port
-    # within the machine from a port on the host machine.
-    # ex: config.vm.network "forwarded_port", guest: 49156, host: 9876
-    $forwarded_ports.each do |guest, host|
-      config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
-    end
-
-    ["vmware_fusion", "vmware_workstation"].each do |vmware|
-      config.vm.provider vmware do |v|
-        v.gui = vm_gui
-        v.vmx['memsize'] = vm_memory
-        v.vmx['numvcpus'] = vm_cpus
+      # Create a forwarded port mapping which allows access to a specific port
+      # within the machine from a port on the host machine.
+      # ex: config.vm.network "forwarded_port", guest: 49156, host: 9876
+      $forwarded_ports.each do |guest, host|
+        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end
-    end
 
-    config.vm.provider :virtualbox do |vb|
-      vb.gui = vm_gui
-      vb.memory = vm_memory
-      vb.cpus = vm_cpus
-    end
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        config.vm.provider vmware do |v|
+          v.gui = vm_gui
+          v.vmx['memsize'] = vm_memory
+          v.vmx['numvcpus'] = vm_cpus
+        end
+      end
 
-    config.vm.network :private_network, ip: $ip
+      config.vm.provider :virtualbox do |vb|
+        vb.gui = vm_gui
+        vb.memory = vm_memory
+        vb.cpus = vm_cpus
+      end
 
-    # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
-    #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
-    $shared_folders.each_with_index do |(host_folder, guest_folder), index|
-      config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
-    end
+      config.vm.network :private_network, ip: ip
 
-    if $share_home
-      config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']
-    end
+      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
+      #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      $shared_folders.each_with_index do |(host_folder, guest_folder), index|
+        config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
+      end
 
-    system "echo '\n********\nCurrent Role: #{$role} \nMachine Name: #{$machine_name}\n********\n'"
-    if $role == "master"
-      config.vm.provision :file, :source => $master_data_path, :destination => "/tmp/vagrantfile-user-data"
-      config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+      if $share_home
+        config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      end
 
-      # kick start etcd2 service
-      config.vm.provision :file, :source => $etcd_start_script_path, :destination => "/tmp/etcd-start"
-      config.vm.provision :shell, :inline => "chmod +x /tmp/etcd-start && /tmp/etcd-start", :privileged => true
-    else
-      config.vm.provision :file, :source => $node_data_path, :destination => "/tmp/vagrantfile-user-data"
-      config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+      system "echo '\n********\nCurrent Role: #{role} \nMachine Name: #{hostname}\n********\n'"
+      if role == "master"
+        config.vm.provision :file, :source => $master_data_path, :destination => "/tmp/vagrantfile-user-data"
+        config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+
+        # kick start etcd2 service
+        config.vm.provision :file, :source => $etcd_start_script_path, :destination => "/tmp/etcd-start"
+        config.vm.provision :shell, :inline => "chmod +x /tmp/etcd-start && /tmp/etcd-start", :privileged => true
+      else
+        config.vm.provision :file, :source => $node_data_path, :destination => "/tmp/vagrantfile-user-data"
+        config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+      end
     end
   end
 end

--- a/setup/cleanup
+++ b/setup/cleanup
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -e
 
-IP=172.17.8.101 NUM=1 vagrant destroy -f
-
-IP=172.17.8.102 NUM=2 vagrant destroy -f
-
-ROLE=master vagrant destroy -f
+vagrant destroy -f
 
 rm -rf ~/.fleetctl/known_hosts
 

--- a/setup/cloud-init/node-data
+++ b/setup/cloud-init/node-data
@@ -8,7 +8,7 @@ coreos:
     proxy: on
     # replace it with actual names and ips when before bootstrapping
     # initial-cluster: ${NAME1=PRIVATE_IP1,NAME2=PRIVATE_IP2,NAME3=PRIVATE_IP3}
-    initial-cluster: "25183d20c0ad47608a627c764f034778=http://172.17.8.100:2380"
+    initial-cluster: "6d8d9d9299154a1f9a94d751f76e31ec=http://172.17.8.100:2380"
 
   fleet:
     public-ip: $public_ipv4


### PR DESCRIPTION
This fits how people do it normally.

So we could `vagrant destroy` to destroy all machines, and `vagrant status` could list status of all VMs.
